### PR TITLE
Work to bring code in line with unit tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,9 +10,10 @@
 
 'use strict';
 
-var path = require('path'),
-  fs = require('fs'),
-  viewsPath = __dirname + '/views';
+var path = require('path')
+  , fs = require('fs')
+  , viewsPath = __dirname + '/views'
+  , globals = require('./globals');
   // viewsPath = __dirname + '/../../views';
 
 
@@ -20,6 +21,7 @@ var path = require('path'),
 if(!fs.existsSync(__dirname + '/tmp')) {
   fs.mkdirSync(__dirname + '/tmp');
 }
+
 
 
 module.exports = function(grunt) {
@@ -45,6 +47,8 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     generate_layout : {
       all_layouts : {
+        globals: globals,
+        
         files : [{
           expand : true,
           cwd : viewsPath + '/layouts/',
@@ -57,6 +61,8 @@ module.exports = function(grunt) {
 
     generate_templates : {
       all_hbs : {
+        globals:globals,
+        
         files : [{
           expand : true,
           cwd : viewsPath + '/',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,6 @@ if(!fs.existsSync(__dirname + '/tmp')) {
 }
 
 
-
 module.exports = function(grunt) {
 
   // Project configuration.

--- a/GruntfileDev.js
+++ b/GruntfileDev.js
@@ -10,8 +10,9 @@
 
 'use strict';
 
-var path = require('path'),
-  viewsPath = __dirname + '/../../views';
+var path = require('path')
+  , viewsPath = __dirname + '/../../views'
+  , globals = require('./globals');
 
 
 module.exports = function(grunt) {
@@ -36,6 +37,8 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     generate_layout : {
       all_layouts : {
+        globals: globals,
+        
         files : [{
           expand : true,
           cwd : viewsPath + '/layouts/',
@@ -48,6 +51,8 @@ module.exports = function(grunt) {
 
     generate_templates : {
       all_hbs : {
+        globals: globals,
+        
         files : [{
           expand : true,
           cwd : viewsPath + '/',

--- a/globals.js
+++ b/globals.js
@@ -4,6 +4,6 @@ var grunt = require('grunt')
 
 module.exports = {
   
-  versionHeader: "<#-- TEST grunt-hbs2ftl v." + pkg.version + " -->\n"
+  versionHeader: "<#-- grunt-hbs2ftl v." + pkg.version + " -->\n"
 
 };

--- a/globals.js
+++ b/globals.js
@@ -1,0 +1,9 @@
+var grunt = require('grunt')
+  , pkg = grunt.file.readJSON( __dirname + '/package.json');
+
+
+module.exports = {
+  
+  versionHeader: "<#-- TEST grunt-hbs2ftl v." + pkg.version + " -->\n"
+
+};

--- a/tasks/generate_layout.js
+++ b/tasks/generate_layout.js
@@ -13,11 +13,13 @@
 var convert = require(__dirname + '/../modules/converter/converter.js');
 
 module.exports = function(grunt) {
-  var pkg = grunt.file.readJSON( __dirname + '/../package.json');
 
   grunt.registerMultiTask('generate_layout', 'Converts express-hbs layout meta-templates Freemarker "layouts"', function() {
     //console.log('@generate_layout with ' + this.files.length + ' files');
     var fp;
+    
+    // lets not lose our header to scope
+    var versionHeader = this.data.globals.versionHeader;
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -65,7 +67,7 @@ module.exports = function(grunt) {
       src = convert.ftlTrim(src);
 
       // add version tag
-      src = '<#-- grunt-hbs2ftl v.' + pkg.version + ' -->\n' + src;
+      src = versionHeader + src;
   
       grunt.file.write(f.dest, src, { encoding : 'utf8'});
 

--- a/tasks/generate_templates.js
+++ b/tasks/generate_templates.js
@@ -13,14 +13,17 @@
 var convert = require(__dirname + '/../modules/converter/converter.js');
 
 module.exports = function(grunt) {
-
-  var pkg = grunt.file.readJSON( __dirname + '/../package.json');
+  //console.log(grunt);
 
   grunt.registerMultiTask('generate_templates', 'Converts handlebarsJS templates into Freemarker templates', function() {
     console.log('@generate_templates with ' + this.files.length + ' files');
 
+    // lets not lose our header to scope
+    var versionHeader = this.data.globals.versionHeader;
+
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
+
       var src = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
@@ -94,7 +97,7 @@ module.exports = function(grunt) {
       // html minify
       src = convert.ftlTrim(src);
 
-      src = '<#-- grunt-hbs2ftl v.' + pkg.version + ' -->\n' + src;
+      src = versionHeader + src;
       
       src = src.trim();
       

--- a/tasks/generate_templates.js
+++ b/tasks/generate_templates.js
@@ -13,7 +13,6 @@
 var convert = require(__dirname + '/../modules/converter/converter.js');
 
 module.exports = function(grunt) {
-  //console.log(grunt);
 
   grunt.registerMultiTask('generate_templates', 'Converts handlebarsJS templates into Freemarker templates', function() {
     console.log('@generate_templates with ' + this.files.length + ' files');

--- a/test/001-hbsEach_test.js
+++ b/test/001-hbsEach_test.js
@@ -1,7 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt')
+  , globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -38,6 +39,9 @@ exports.generate_layout = {
     
     actual = actual.replace(/[\r\n]+/gim, '\n');
     expected = expected.replace(/[\r\n]+/gim, '\n');
+    
+    //lets not compare the versionHeader since that could/should be dynamic (and wont match our static expectations)
+    actual = actual.replace( globals.versionHeader, '' );
     
     test.equal(actual, expected, 'HandlebarsJS {{#each}} should convert to Freemarker and contextualize all variables within its scope.');
 

--- a/test/002-hbsEach-nested_test.js
+++ b/test/002-hbsEach-nested_test.js
@@ -1,7 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt')
+  , globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -38,6 +39,9 @@ exports.generate_layout = {
     
     actual = actual.replace(/[\r\n]+/gim, '\n');
     expected = expected.replace(/[\r\n]+/gim, '\n');
+    
+    //lets not compare the versionHeader since that could/should be dynamic (and wont match our static expectations)
+    actual = actual.replace( globals.versionHeader, '' );
     
     test.equal(actual, expected, 'HandlebarsJS {{#each}} should convert to Freemarker and contextualize all variables within its scope.');
 

--- a/test/003-hbsEach-deep_test.js
+++ b/test/003-hbsEach-deep_test.js
@@ -1,7 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt')
+  , globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -38,6 +39,9 @@ exports.test = {
     
     actual = actual.replace(/[\r\n]+/gim, '\n');
     expected = expected.replace(/[\r\n]+/gim, '\n');
+    
+    //lets not compare the versionHeader since that could/should be dynamic (and wont match our static expectations)
+    actual = actual.replace( globals.versionHeader, '' );
     
     test.equal(actual, expected, 'HandlebarsJS {{#each}} should convert to Freemarker and contextualize all variables within its scope.');
 

--- a/test/004-hbsWith_test.js
+++ b/test/004-hbsWith_test.js
@@ -1,7 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt')
+  , globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -37,6 +38,9 @@ exports.test = {
     
     actual = actual.replace(/[\r\n]+/gim, '\n');
     expected = expected.replace(/[\r\n]+/gim, '\n');
+    
+    //lets not compare the versionHeader since that could/should be dynamic (and wont match our static expectations)
+    actual = actual.replace( globals.versionHeader, '' );
     
     test.equal(actual, expected, 'HandlebarsJS {{#each}} should convert to Freemarker and contextualize all variables within its scope.');
 

--- a/test/generate_layout_test.js
+++ b/test/generate_layout_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt')
+  , globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -37,6 +38,9 @@ exports.generate_layout = {
     
     actual = actual.replace(/[\r\n]+/gim, '\n');
     expected = expected.replace(/[\r\n]+/gim, '\n');
+    
+    //lets not compare the versionHeader since that could/should be dynamic (and wont match our static expectations)
+    actual = actual.replace( globals.versionHeader, '' );
     
     test.equal(actual, expected, 'express-hbs layout should be converted to the Freemarker equivalent.');
 

--- a/test/generate_view_test.js
+++ b/test/generate_view_test.js
@@ -1,6 +1,8 @@
  'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt')
+  , globals = require('./../globals.js');
+
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -49,6 +51,9 @@ exports.generate_layout = {
 
     converted = converted.replace(/[\r\n]+/gim, '\n');
     converted = converted.trim();
+    
+    //lets not compare the versionHeader since that could/should be dynamic (and wont match our static expectations)
+    converted = converted.replace( globals.versionHeader, '' );
 
     expected = expected.replace(/[\r\n]+/gim, '\n');
     expected = expected.trim();


### PR DESCRIPTION
Noticed that all 6 unit tests were failing. They were mismatching the expects/actuals because of the inserted version header comment tag, which is dynamic. Making it accessible globally (between grunt tasks and unit tests) unifies the header definition to one location, and allows the tests to ignore it and compare actual results.

This corrects 2 of the 6 unit tests. The remaining for fails are mismatching to ongoing adjustments by Aaron to correct the compiled ftl templates, and should be corrected once his work is complete.
