### PR TITLE
Corrected issues that would block on tom.dev

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    viewsPath = __dirname + '/views',
-    globals = require('./globals');
+    viewsPath = __dirname + '/views';
   // viewsPath = __dirname + '/../../views';
 
 
@@ -46,8 +45,6 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     generate_layout : {
       all_layouts : {
-        globals: globals,
-        
         files : [{
           expand : true,
           cwd : viewsPath + '/layouts/',
@@ -60,8 +57,6 @@ module.exports = function(grunt) {
 
     generate_templates : {
       all_hbs : {
-        globals:globals,
-        
         files : [{
           expand : true,
           cwd : viewsPath + '/',

--- a/GruntfileDev.js
+++ b/GruntfileDev.js
@@ -11,8 +11,7 @@
 'use strict';
 
 var path = require('path'),
-    viewsPath = __dirname + '/../../views',
-    globals = require('./globals');
+    viewsPath = __dirname + '/../../views';
 
 
 module.exports = function(grunt) {
@@ -37,8 +36,6 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     generate_layout : {
       all_layouts : {
-        globals: globals,
-        
         files : [{
           expand : true,
           cwd : viewsPath + '/layouts/',

--- a/GruntfileDev.js
+++ b/GruntfileDev.js
@@ -48,8 +48,6 @@ module.exports = function(grunt) {
 
     generate_templates : {
       all_hbs : {
-        globals: globals,
-        
         files : [{
           expand : true,
           cwd : viewsPath + '/',

--- a/tasks/generate_layout.js
+++ b/tasks/generate_layout.js
@@ -10,16 +10,14 @@
 'use strict';
 
 
-var convert = require(__dirname + '/../modules/converter/converter.js');
+var convert = require(__dirname + '/../modules/converter/converter.js'),
+    globals = require(__dirname + '/../globals');
 
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('generate_layout', 'Converts express-hbs layout meta-templates Freemarker "layouts"', function() {
     //console.log('@generate_layout with ' + this.files.length + ' files');
     var fp;
-    
-    // lets not lose our header to scope
-    var versionHeader = this.data.globals.versionHeader;
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -67,7 +65,7 @@ module.exports = function(grunt) {
       src = convert.ftlTrim(src);
 
       // add version tag
-      src = versionHeader + src;
+      src = globals.versionHeader + src;
   
       grunt.file.write(f.dest, src, { encoding : 'utf8'});
 

--- a/tasks/generate_templates.js
+++ b/tasks/generate_templates.js
@@ -10,15 +10,13 @@
 'use strict';
 
 
-var convert = require(__dirname + '/../modules/converter/converter.js');
+var convert = require(__dirname + '/../modules/converter/converter.js'),
+    globals = require(__dirname + '/../globals');
 
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('generate_templates', 'Converts handlebarsJS templates into Freemarker templates', function() {
     console.log('@generate_templates with ' + this.files.length + ' files');
-
-    // lets not lose our header to scope
-    var versionHeader = this.data.globals.versionHeader;
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -96,7 +94,7 @@ module.exports = function(grunt) {
       // html minify
       src = convert.ftlTrim(src);
 
-      src = versionHeader + src;
+      src = globals.versionHeader + src;
       
       src = src.trim();
       

--- a/test/001-hbsEach_test.js
+++ b/test/001-hbsEach_test.js
@@ -1,8 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========

--- a/test/002-hbsEach-nested_test.js
+++ b/test/002-hbsEach-nested_test.js
@@ -1,8 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========

--- a/test/003-hbsEach-deep_test.js
+++ b/test/003-hbsEach-deep_test.js
@@ -1,8 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========

--- a/test/004-hbsWith_test.js
+++ b/test/004-hbsWith_test.js
@@ -1,8 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========

--- a/test/005-hbsNoEscape_test.js
+++ b/test/005-hbsNoEscape_test.js
@@ -1,8 +1,8 @@
 //hbsEach
 'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 exports.test = {
   setUp: function(done) {

--- a/test/generate_layout_test.js
+++ b/test/generate_layout_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========

--- a/test/generate_view_test.js
+++ b/test/generate_view_test.js
@@ -1,7 +1,7 @@
  'use strict';
 
-var grunt = require('grunt')
-  , globals = require('./../globals.js');
+var grunt = require('grunt'),
+    globals = require('./../globals.js');
 
 
 /*


### PR DESCRIPTION
Moved version header tag declaration back into tasks so they aren't lost when alternative grunt files are used (kinda the point, sorry I missed this). Corrected comma styling to maintain current implementation and pass jslint.
